### PR TITLE
Autoload comments

### DIFF
--- a/yaml-mode.el
+++ b/yaml-mode.el
@@ -214,6 +214,7 @@ that key is pressed to begin a block literal."
   (modify-syntax-entry ?\[ "(]" yaml-mode-syntax-table)
   (modify-syntax-entry ?\] ")[" yaml-mode-syntax-table))
 
+;;;###autoload
 (define-derived-mode yaml-mode fundamental-mode "YAML"
   "Simple mode to edit YAML.
 
@@ -403,6 +404,9 @@ margin."
   (interactive)
   (message "yaml-mode %s" yaml-mode-version)
   yaml-mode-version)
+
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.yml$" . yaml-mode))
 
 (provide 'yaml-mode)
 


### PR DESCRIPTION
I've added a few autoload comments (i.e. `;;;###autoload`) to `yaml-mode.el`. They instruct `update-directory-autoloads` on how to autoload the package and are useful for ELPA to install and configure the package more easily. I also took the liberty of including the association with `.yml` files inside the file.
