### PR TITLE
patch for suppressing warnings

### DIFF
--- a/yaml-mode.el
+++ b/yaml-mode.el
@@ -367,7 +367,7 @@ and indents appropriately."
   (interactive "*P")
   (self-insert-command (prefix-numeric-value arg))
   (let ((extra-chars
-         (assoc last-command-char
+         (assoc last-command-event
                 yaml-block-literal-electric-alist)))
     (cond
      ((and extra-chars (not arg) (eolp)


### PR DESCRIPTION
In emacs 23.4, this warns:

```
In yaml-electric-bar-and-angle:
yaml-mode.el:370:17:Warning: `last-command-char' is an obsolete variable (as
    of Emacs at least 19.34); use `last-command-event' instead.
```
