### PR TITLE
Remove default C-j binding

### DIFF
--- a/yaml-mode.el
+++ b/yaml-mode.el
@@ -194,8 +194,7 @@ that key is pressed to begin a block literal."
   (define-key yaml-mode-map ">" 'yaml-electric-bar-and-angle)
   (define-key yaml-mode-map "-" 'yaml-electric-dash-and-dot)
   (define-key yaml-mode-map "." 'yaml-electric-dash-and-dot)
-  (define-key yaml-mode-map [backspace] 'yaml-electric-backspace)
-  (define-key yaml-mode-map "\C-j" 'newline-and-indent))
+  (define-key yaml-mode-map [backspace] 'yaml-electric-backspace))
 
 (defvar yaml-mode-syntax-table nil
   "Syntax table in use in `yaml-mode' buffers.")


### PR DESCRIPTION
There's no need to rebind C-j to 'newline-and-indent, as this is the default binding. Rebinding it has no effect for people who use the default, and it clobbers bindings for people who change it.
