### PR TITLE
Use font-lock-flush when available

### DIFF
--- a/yaml-mode.el
+++ b/yaml-mode.el
@@ -226,7 +226,10 @@ that key is pressed to begin a block literal."
        '(yaml-font-lock-keywords
          nil nil nil nil
          (font-lock-syntactic-keywords . yaml-font-lock-syntactic-keywords)))
-  (font-lock-fontify-buffer))
+  (if (fboundp 'font-lock-flush)
+      (font-lock-flush)
+    (with-no-warnings
+      (font-lock-fontify-buffer))))
 
 
 ;; Font-lock support


### PR DESCRIPTION
As of Emacs v25.1 `font-lock-fontify-buffer` should not be used to
have new font-lock keywords take effect.  Instead `font-lock-flush`
should be used.  Do that if it's available, else fall back to
`font-lock-fontify-buffer`.