### PR TITLE
Fix typo in yaml-mode-version docstring

### DIFF
--- a/yaml-mode.el
+++ b/yaml-mode.el
@@ -426,7 +426,7 @@ cross boundaries of block literals."
 
 
 (defun yaml-mode-version ()
-  "Diplay version of `yaml-mode'."
+  "Display version of `yaml-mode'."
   (interactive)
   (message "yaml-mode %s" yaml-mode-version)
   yaml-mode-version)


### PR DESCRIPTION
'diplay' -> 'display'