### PR TITLE
Treat alias nodes as punctuation

### DIFF
--- a/yaml-mode.el
+++ b/yaml-mode.el
@@ -203,6 +203,8 @@ that key is pressed to begin a block literal."
     (modify-syntax-entry ?\\ "\\" syntax-table)
     (modify-syntax-entry ?- "_" syntax-table)
     (modify-syntax-entry ?_ "_" syntax-table)
+    (modify-syntax-entry ?& "." syntax-table)
+    (modify-syntax-entry ?* "." syntax-table)
     (modify-syntax-entry ?\( "." syntax-table)
     (modify-syntax-entry ?\) "." syntax-table)
     (modify-syntax-entry ?\{ "(}" syntax-table)


### PR DESCRIPTION
Previously, Emacs did not understand that `&foo` and `*foo` related to the
same symbol, so tools like `highlight-symbol-mode` did not work.

Relevant section of the YAML spec: http://yaml.org/spec/1.2/spec.html#id2786196