### PR TITLE
Don't consider a line a document delimiter if it has leading whitespace

### DIFF
--- a/yaml-mode.el
+++ b/yaml-mode.el
@@ -125,7 +125,7 @@ that key is pressed to begin a block literal."
 (defconst yaml-directive-re "^\\(?:--- \\)? *%\\(\\w+\\)"
   "Regexp matching a line contatining a YAML directive.")
 
-(defconst yaml-document-delimiter-re "^ *\\(?:---\\|[.][.][.]\\)"
+(defconst yaml-document-delimiter-re "^\\(?:---\\|[.][.][.]\\)"
   "Rexexp matching a YAML document delimiter line.")
 
 (defconst yaml-node-anchor-alias-re "[&*][a-zA-Z0-9_-]+"


### PR DESCRIPTION
The YAML spec says this:

>This line must start with a document separator: “---” followed by a
>line break or a sequence of space characters.

http://yaml.org/spec/1.0/#id2561718

If I'm reading the spec correctly, this seems to mean that a document
separator must appear at the start of the line. The current behavior
causes yaml-mode to interpret three dashes as a document separator even
inside an indented block literal. (https://github.com/yoshiki/yaml-mode/issues/53)