### PR TITLE
Support for apostrophe in words

### DIFF
--- a/yaml-mode.el
+++ b/yaml-mode.el
@@ -245,7 +245,8 @@ that key is pressed to begin a block literal."
    "Additional expressions to highlight in YAML mode.")
 
 (defun yaml-mode-syntax-propertize-function (beg end)
-  "Unhighlight foo#bar tokens between BEG and END."
+  "Override buffer's syntax table for special syntactic constructs."
+  ;; Unhighlight foo#bar tokens between BEG and END.
   (save-excursion
     (goto-char beg)
     (while (search-forward "#" end t)
@@ -255,7 +256,20 @@ that key is pressed to begin a block literal."
         (when (and (not (bolp))
                    (not (memq (preceding-char) '(?\s ?\t))))
           (put-text-property (point) (1+ (point))
-                             'syntax-table (string-to-syntax "_")))))))
+                             'syntax-table (string-to-syntax "_"))))))
+
+  ;; If quote is detected as a syntactic string start but appeared
+  ;; after a non-whitespace character, then mark it as syntactic word.
+  (save-excursion
+    (goto-char beg)
+    (while (search-forward "'" end t)
+      (when (nth 8 (syntax-ppss))
+        (save-excursion
+          (forward-char -1)
+          (when (and (not (bolp))
+                     (not (memq (preceding-char) '(?\s ?\t))))
+            (put-text-property (point) (1+ (point))
+                               'syntax-table (string-to-syntax "w"))))))))
 
 (defun yaml-font-lock-block-literals (bound)
   "Find lines within block literals.


### PR DESCRIPTION
If a quote is written in a word it is handled as a word instead of
starting a string. This fixes the following YAML syntax highlighting:

  server's:
    - here: syntax is not string
    - this: 'is a string'

Previously the first apostrophe/quote started a string, which meant
that the file is highlighted as a string until the next quote is met.

The single quote string detection now requires that the previous character
is a whitespace, which means that:

  this:'is detected incorrectly'

without the space the above does not detect a string.

Fixes #20 and fixes #39 (duplicate)