### PR TITLE
Support non-whitespace preceded apostrophe

### DIFF
--- a/yaml-mode.el
+++ b/yaml-mode.el
@@ -262,7 +262,7 @@ that key is pressed to begin a block literal."
   ;; after a non-whitespace character, then mark it as syntactic word.
   (save-excursion
     (goto-char beg)
-    (while (search-forward "'" end t)
+    (while (re-search-forward "['\"]" end t)
       (when (nth 8 (syntax-ppss))
         (save-excursion
           (forward-char -1)

--- a/yaml-mode.el
+++ b/yaml-mode.el
@@ -266,10 +266,14 @@ that key is pressed to begin a block literal."
       (when (nth 8 (syntax-ppss))
         (save-excursion
           (forward-char -1)
-          (when (and (not (bolp))
-                     (char-equal ?w (char-syntax (char-before (point)))))
-            (put-text-property (point) (1+ (point))
-                               'syntax-table (string-to-syntax "w"))))))))
+          (cond ((and (char-equal ?' (char-before (point)))
+                      (char-equal ?' (char-after (point)))
+                      (put-text-property (1- (point)) (1+ (point))
+                                         'syntax-table (string-to-syntax "w"))))
+                ((and (not (bolp))
+                      (char-equal ?w (char-syntax (char-before (point)))))
+                 (put-text-property (point) (1+ (point))
+                                    'syntax-table (string-to-syntax "w")))))))))
 
 (defun yaml-font-lock-block-literals (bound)
   "Find lines within block literals.

--- a/yaml-mode.el
+++ b/yaml-mode.el
@@ -267,7 +267,7 @@ that key is pressed to begin a block literal."
         (save-excursion
           (forward-char -1)
           (when (and (not (bolp))
-                     (not (memq (preceding-char) '(?\s ?\t))))
+                     (char-equal ?w (char-syntax (char-before (point)))))
             (put-text-property (point) (1+ (point))
                                'syntax-table (string-to-syntax "w"))))))))
 


### PR DESCRIPTION
The previous version handles apostrophe as a quote if it was preceded
by a whitespace. This version checks the syntax of the preceding
character, if it's part of a word then it's handled as an apostrophe,
otherwise as a quote.

Fixes previously broken situations with JSON style lists.

Fixes #58