### PR TITLE
fixes #60

### DIFF
--- a/yaml-mode.el
+++ b/yaml-mode.el
@@ -297,7 +297,7 @@ artificially limitted to the value of
                   (not (bobp)))
         (forward-line -1))
       (let ((nlines yaml-block-literal-search-lines)
-            (min-level (current-indentation)))
+            (min-level (- (current-indentation) yaml-indent-offset)))
         (forward-line -1)
         (while (and (/= nlines 0)
                     (/= min-level 0)


### PR DESCRIPTION
- Possible fix for #60 
- Modifies `yaml-font-lock-block-literals` to initialize `min-level` to `((current-indentation) - yaml-indent-offset)`

Frankly, I don't grok the code, so caveat emptor and all that. This fix was based on twiddling with the parameters/variables till something stuck. 