### PR TITLE
fill while in a comment should behave as in text modes

### DIFF
--- a/yaml-mode.el
+++ b/yaml-mode.el
@@ -438,13 +438,15 @@ otherwise do nothing."
 
 (defun yaml-fill-paragraph (&optional justify region)
   "Fill paragraph.
-This behaves as `fill-paragraph' except that filling does not
-cross boundaries of block literals."
+Outside of comments, this behaves as `fill-paragraph' except that
+filling does not cross boundaries of block literals.  Inside comments,
+this will do usual adaptive fill behaviors."
   (interactive "*P")
   (save-restriction
     (yaml-narrow-to-block-literal)
     (let ((fill-paragraph-function nil))
-      (fill-paragraph justify region))))
+      (or (fill-comment-paragraph justify)
+          (fill-paragraph justify region)))))
 
 (defun yaml-set-imenu-generic-expression ()
   (make-local-variable 'imenu-generic-expression)


### PR DESCRIPTION
This fixes a bug in fill-paragraph that made adaptive fill not work
while in a comment (probably the only time it matters in yaml-mode).

This change does what lisp-mode does: first, try fill-comment-paragraph.
If fill-comment-paragraph does the fill, great; we're in a comment, and
the right thing happens.  If it returns nil, it can't do the fill, and
we can fall back to the previous method.

Without this change, a paragraph break inside a comment, or other things
that adaptive fill would generally detect, are not respected.