### PR TITLE
Fix indent after comment line

### DIFF
--- a/yaml-mode.el
+++ b/yaml-mode.el
@@ -151,7 +151,7 @@ that key is pressed to begin a block literal."
   "Regexp indicating the beginning of a scalar context.")
 
 (defconst yaml-nested-map-re
-  (concat ".*: *\\(?:&.*\\|{ *\\|" yaml-tag-re " *\\)?$")
+  (concat "[^#]*: *\\(?:&.*\\|{ *\\|" yaml-tag-re " *\\)?$")
   "Regexp matching a line beginning a YAML nested structure.")
 
 (defconst yaml-block-literal-base-re " *[>|][-+0-9]* *\\(?:\n\\|\\'\\)"


### PR DESCRIPTION
Make sure that the nested indent line isn't actually a comment ending in a colon

Fixes: https://github.com/yoshiki/yaml-mode/issues/65