### PR TITLE
Fix propertization for sequences of mappings with literal block

### DIFF
--- a/test-files/test-syntax-highlighting-list-of-dicts-containing-literal-block.yaml
+++ b/test-files/test-syntax-highlighting-list-of-dicts-containing-literal-block.yaml
@@ -1,0 +1,8 @@
+# Propertized incorrectly prior to PR
+example:
+  - key1: Correctly propertized
+    key2: |
+      Correctly propertized.
+  - key3: |
+      Correctly propertized
+    key4: Incorrectly propertized as part of preceding yaml-literal-block

--- a/yaml-mode.el
+++ b/yaml-mode.el
@@ -322,6 +322,8 @@ artificially limited to the value of
           (unless (looking-at yaml-blank-line-re)
             (setq min-level (min min-level (current-indentation))))
           (forward-line -1))
+        (when (looking-at-p " *- ")
+          (setq min-level (- min-level 2)))
         (cond
          ((and (< (current-indentation) min-level)
                (looking-at yaml-block-literal-re))


### PR DESCRIPTION
The syntax highlighting is broken for lists of dicts where one of the dictionary elements is a literal block.
This small fix handles this case.

```yaml
example:
  - key1: Correctly highlighted
    key2: |
      Correctly highlighted.
  - key3: |
      Correctly highlighted
    key4: Incorrectly highlighted as part of preceding yaml-literal-block
```


In submitting this PR I'm noticing that the github markdown rendering is incorrect too ^^^.
I double checked with the python parser you get a two element list, each of which is a dict with two entries.
e.g:
```python3
import yaml
import json

doc = """
example:
  - key1: Correctly highlighted
    key2: |
      Correctly highlighted.
  - key3: |
      Correctly highlighted
    key4: Incorrectly highlighted as part of preceding yaml-literal-block
"""

print(json.dumps(yaml.load(doc, Loader=yaml.CLoader), indent=2))
```
Prints
```json
{
  "Example": [
    {
      "key1": "Correctly highlighted",
      "key2": "Correctly highlighted.\n"
    },
    {
      "key3": "Correctly highlighted\n",
      "key4": "Incorrectly highlighted as part of preceding yaml-literal-block"
    }
  ]
}
```



