### PR TITLE
Derive yaml-mode from prog-mode and wrap long lines by default

### DIFF
--- a/yaml-mode.el
+++ b/yaml-mode.el
@@ -215,10 +215,11 @@ that key is pressed to begin a block literal."
   "Syntax table in use in `yaml-mode' buffers.")
 
 ;;;###autoload
-(define-derived-mode yaml-mode text-mode "YAML"
+(define-derived-mode yaml-mode prog-mode "YAML"
   "Simple mode to edit YAML.
 
-\\{yaml-mode-map}"
+\\{yaml-mode-map}
+paaguti: try to derive from prog-mode"
   :syntax-table yaml-mode-syntax-table
   (set (make-local-variable 'comment-start) "# ")
   (set (make-local-variable 'comment-start-skip) "#+ *")
@@ -473,6 +474,11 @@ this will do usual adaptive fill behaviors."
 
 (add-hook 'yaml-mode-hook 'yaml-set-imenu-generic-expression)
 
+(add-hook 'yaml-mode-hook #'(lambda ()
+                              "Since we derive from prog-mode,
+make sure we wrap lines for example, for ssh public keys"
+                              (setq truncate-lines nil)))
+
 
 (defun yaml-mode-version ()
   "Display version of `yaml-mode'."
@@ -482,6 +488,7 @@ this will do usual adaptive fill behaviors."
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.\\(e?ya?\\|ra\\)ml\\'" . yaml-mode))
+
 
 (provide 'yaml-mode)
 


### PR DESCRIPTION
HI,

I'm using yaml-mode mainly for cloud-config. I derive it from prog-mode, because deriving it from text-mode adds an extra menu 'Text' which makes little sense for yaml. The interface is (IMvHO) much cleaner and allows me to create a specific YAML menu entry with utility functions for cloud-config file handling.