### PR TITLE
Make Imenu index non-alphabetic mapping keys and anchors

### DIFF
--- a/yaml-mode.el
+++ b/yaml-mode.el
@@ -110,7 +110,8 @@ that key is pressed to begin a block literal."
   :group 'yaml)
 
 (defcustom yaml-imenu-generic-expression
-  '((nil  "^\\(:?[a-zA-Z_-]+\\):"          1))
+  '((nil  "^\\(:?[^{}(),\s \n]+\\):"          1)
+    ("*Anchors*" "^\\s *[^{}(),\s \n]+: \\&\\([^{}(),\s \n]+\\)" 1))
   "The imenu regex to parse an outline of the yaml file."
   :type 'string
   :group 'yaml)


### PR DESCRIPTION
Mapping keys need not be made of alphabetic chars. The proposed change makes Imenu index mapping keys made of non-alphabetic characters. It also makes Imenu index anchors.