### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/yaml-mode.el
+++ b/yaml-mode.el
@@ -306,8 +306,8 @@ artificially limited to the value of
   (if (eolp) (goto-char (1+ (point))))
   (unless (or (eobp) (>= (point) bound))
     (let ((begin (point))
-          (end (min (1+ (point-at-eol)) bound)))
-      (goto-char (point-at-bol))
+          (end (min (1+ (line-end-position)) bound)))
+      (goto-char (line-beginning-position))
       (while (and (looking-at yaml-blank-line-re)
                   (not (bobp)))
         (forward-line -1))
@@ -426,7 +426,7 @@ margin."
 otherwise do nothing."
   (interactive)
   (save-excursion
-    (goto-char (point-at-bol))
+    (goto-char (line-beginning-position))
     (while (and (looking-at-p yaml-blank-line-re) (not (bobp)))
       (forward-line -1))
     (let ((nlines yaml-block-literal-search-lines)


### PR DESCRIPTION
point-at-bol and point-at-eol are obsoleted since Emacs 29.1. Emacs 24.1 which is minimum supported version of yaml-mode supports `line-beginning-position`, `line-end-position`. https://github.com/emacs-mirror/emacs/blob/emacs-24.1/src/editfns.c#L774

```
yaml-mode.el:309:26: Warning: ‘point-at-eol’ is an obsolete function (as of
    29.1); use ‘line-end-position’ instead.
yaml-mode.el:310:19: Warning: ‘point-at-bol’ is an obsolete function (as of
    29.1); use ‘line-beginning-position’ instead.

In yaml-narrow-to-block-literal:
yaml-mode.el:429:17: Warning: ‘point-at-bol’ is an obsolete function (as of
    29.1); use ‘line-beginning-position’ instead.
```