### PR TITLE
Do not modify the buffer in `yaml-indent-line` unless necessary

### DIFF
--- a/yaml-mode.el
+++ b/yaml-mode.el
@@ -368,11 +368,9 @@ back-dent the line by `yaml-indent-offset' spaces.  On reaching column
   (let ((ci (current-indentation))
         (need (yaml-compute-indentation)))
     (save-excursion
-      (beginning-of-line)
-      (delete-horizontal-space)
       (if (and (equal last-command this-command) (/= ci 0))
-          (indent-to (* (/ (- ci 1) yaml-indent-offset) yaml-indent-offset))
-        (indent-to need)))
+          (indent-line-to (* (/ (- ci 1) yaml-indent-offset) yaml-indent-offset))
+        (indent-line-to need)))
     (if (< (current-column) (current-indentation))
         (forward-to-indentation 0))))
 


### PR DESCRIPTION
This is a dup of the [closed PR](https://github.com/yoshiki/yaml-mode/pull/104), because the latter can't be reopened.

-------------

Calling (yaml-indent-line) for the first time on a line that the function already deems indented correctly results in the buffer getting modified even though there was nothing to modify. This is because the function unconditionally removes space at the beginning of line and then re-indents text back.

Fix this by replacing the `bol` + `delete-horizontal-space` + `indent-to` combination with a call to `indent-line-to` which does the right thing.