### PR TITLE
Allow page navigation

### DIFF
--- a/yaml-mode.el
+++ b/yaml-mode.el
@@ -225,6 +225,7 @@ that key is pressed to begin a block literal."
   (set (make-local-variable 'indent-line-function) 'yaml-indent-line)
   (set (make-local-variable 'indent-tabs-mode) nil)
   (set (make-local-variable 'fill-paragraph-function) 'yaml-fill-paragraph)
+  (set (make-local-variable 'page-delimiter) "^---[[:space:]]*\n")
 
   (set (make-local-variable 'syntax-propertize-function)
        'yaml-mode-syntax-propertize-function)

--- a/yaml-mode.el
+++ b/yaml-mode.el
@@ -225,7 +225,7 @@ that key is pressed to begin a block literal."
   (set (make-local-variable 'indent-line-function) 'yaml-indent-line)
   (set (make-local-variable 'indent-tabs-mode) nil)
   (set (make-local-variable 'fill-paragraph-function) 'yaml-fill-paragraph)
-  (set (make-local-variable 'page-delimiter) "^---[[:space:]]*\n")
+  (set (make-local-variable 'page-delimiter) "^---\\([ \t].*\\)*\n")
 
   (set (make-local-variable 'syntax-propertize-function)
        'yaml-mode-syntax-propertize-function)


### PR DESCRIPTION
I have some YAML files which supports multiple [documents](https://yaml.org/spec/1.0/#syntax-stream-doc).

Emacs support navigating between page using `C-x [` and `C-x ]` which maps to `backward-page` and `forward-page`. This commit  sets `page-delimiter` to the YAML document delimiter `---` to map Emacs notion of page to YAML documents.
