### PR TITLE
Stop using removed :reverse-video face attribute

### DIFF
--- a/yaml-mode.el
+++ b/yaml-mode.el
@@ -103,7 +103,7 @@ that key is pressed to begin a block literal."
 
 (defface yaml-tab-face
   '((((class color)) (:background "red" :foreground "red" :bold t))
-    (t (:reverse-video t)))
+    (t (:inverse-video t)))
   "Face to use for highlighting tabs in YAML files."
   :group 'faces
   :group 'yaml)


### PR DESCRIPTION
The byte-compiler of Emacs 31 has started warning about this.

```
lib/yaml-mode/yaml-mode.el:106:9: Warning: in defface for
‘yaml-tab-face’: Face attribute ‘:reverse-video’ has been
removed; use ‘:inverse-video’ instead
```

`:inverse-video` has been available since before Emacs 24.1
(the minimal Emacs release required by this package).