### PR TITLE
Decipher `auto-mode-alist` regexp and unbreak `.yml` support

### DIFF
--- a/yaml-mode.el
+++ b/yaml-mode.el
@@ -480,7 +480,8 @@ this will do usual adaptive fill behaviors."
   yaml-mode-version)
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.\\(e?ya?\\|ra\\)ml\\'" . yaml-mode))
+(add-to-list 'auto-mode-alist
+             `(,(rx ?. (or "raml" "yaml" "yml" "eyml" "eyaml") string-end) . yaml-mode))
 
 ;;;###autoload
 (add-to-list 'magic-mode-alist


### PR DESCRIPTION
I noticed that `.yml` files are not being opened in YAML mode. Further research showed almost unreadable regular expression, which apparently supposed to support `.yml` files, but failed to do so. Digging into the history to see what exactly extensions were supposed to be supported by this regexp showed:

* raml  — commit c4fd9404
* eyaml — commit 11df4031
* yml, yaml — prior to above commits

So use `rx` macro to enlist aforementioned extensions explicitly, and unbreak support for `yml` at the same time.

CC: @rhoml @scop 