### PR TITLE
feat(indentation): handle indentation in a whitespace aware manner

### DIFF
--- a/test-files/yaml-mode-comments.erts
+++ b/test-files/yaml-mode-comments.erts
@@ -1,0 +1,5 @@
+Name: test-yaml-indentation-comments
+=-=
+version: 1 # should not matter
+host:
+=-=-=

--- a/test-files/yaml-mode-deep.erts
+++ b/test-files/yaml-mode-deep.erts
@@ -1,0 +1,8 @@
+Name: test-yaml-indentation-deep
+=-=
+a:
+  foo: bar
+  bar: baz
+b:
+  1
+=-=-=

--- a/test-files/yaml-mode-list-items-with-dash.erts
+++ b/test-files/yaml-mode-list-items-with-dash.erts
@@ -1,0 +1,7 @@
+Name: test-yaml-indentation-list-items
+=-=
+items:
+  - item1
+  - item2
+  - item3
+=-=-=

--- a/test-files/yaml-mode-quotes-in-strings.erts
+++ b/test-files/yaml-mode-quotes-in-strings.erts
@@ -1,0 +1,9 @@
+Name: test-yaml-indentation-deep
+=-=
+some's'strings'some's'nots:
+- here: syntax is not string
+- this: 'is a string with "quotes"'
+- and: 'to express one single quote, use '' two of them'
+- finally: syntax is not string
+- singlequotedoesntfreeze: '
+=-=-=

--- a/test-files/yaml-mode-sanity.erts
+++ b/test-files/yaml-mode-sanity.erts
@@ -1,0 +1,7 @@
+Name: test-yaml-indentation-sanity
+=-=
+foo:
+  bar: 1
+  baz:
+    qux: 2
+=-=-=

--- a/test-files/yaml-mode-simple.erts
+++ b/test-files/yaml-mode-simple.erts
@@ -1,0 +1,5 @@
+Name: test-yaml-indentation-simple
+=-=
+version: 1
+host:
+=-=-=

--- a/test/yaml-mode-indentation-test.el
+++ b/test/yaml-mode-indentation-test.el
@@ -1,0 +1,66 @@
+;;;; test-yaml-mode.el --- ert Tests for yaml-mode  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; emacs -Q --batch -l ert -L . -l test/yaml-mode-indentation-test.el -f ert-run-tests-batch
+
+(require 'ert)
+
+(load-file "yaml-mode.el")
+(require 'yaml-mode)
+
+
+(ert-deftest test-yaml-mode-indentation-sanity ()
+  "Test YAML indentation case 1 is a sanitycheck to make sure we understand ert files. the ert file contains a single format which is both before and after, it does not contain the optional function and we will do nothing to it so we expect this test to succeed!."
+  (ert-test-erts-file "test-files/yaml-mode-sanity.erts"
+                      (lambda ()
+                        (message "sanitycheck for grokking erts files")
+
+                        )
+                      ))
+(ert-deftest test-yaml-mode-indentation-simple ()
+  "the second line should not indent here."
+  (ert-test-erts-file "test-files/yaml-mode-simple.erts"
+                      (lambda ()
+                        (message (format "before\n%s" (buffer-string)))
+                        (yaml-mode)
+                        (indent-region (point-min) (point-max))
+                        (message (format "after\n%s" (buffer-string))))))
+(ert-deftest test-yaml-mode-indentation-comments ()
+  "comments at the end of the line should not matter."
+  (ert-test-erts-file "test-files/yaml-mode-comments.erts"
+                      (lambda ()
+                        (message (format "before\n%s" (buffer-string)))
+                        (yaml-mode)
+                        (indent-region (point-min) (point-max))
+                        (message (format "after\n%s" (buffer-string))))))
+
+(ert-deftest test-yaml-mode-indentation-deep ()
+  "lets have a look at a deeper nested tree"
+  (ert-test-erts-file "test-files/yaml-mode-deep.erts"
+                      (lambda ()
+                        (message (format "before\n%s" (buffer-string)))
+                        (yaml-mode)
+                        (indent-region (point-min) (point-max))
+                        (message (format "after\n%s" (buffer-string))))))
+
+(ert-deftest test-yaml-mode-indentation-quoted-strings ()
+  "lets have a look at at /yaml-mode/test-files/test-quotes-in-strings.yaml using an erts file"
+  (ert-test-erts-file "test-files/yaml-mode-quotes-in-strings.erts"
+                      (lambda ()
+                        (message (format "before\n%s" (buffer-string)))
+                        (yaml-mode)
+                        (indent-region (point-min) (point-max))
+                        (message (format "after\n%s" (buffer-string))))))
+
+(ert-deftest test-yaml-mode-indentation-yaml-mode-list-items-with-dash ()
+  "lets have a look at at list items  using an erts file"
+  (ert-test-erts-file "test-files/yaml-mode-list-items-with-dash.erts"
+                      (lambda ()
+                        (message (format "before\n%s" (buffer-string)))
+                        (yaml-mode)
+                        (indent-region (point-min) (point-max))
+                        (message (format "after\n%s" (buffer-string))))))
+(provide 'test-yaml-mode)
+
+;;; test-yaml-mode.el ends here

--- a/yaml-mode.el
+++ b/yaml-mode.el
@@ -345,20 +345,8 @@ artificially limited to the value of
 
 
 ;; Indentation and electric keys
-
-(defun yaml-compute-indentation ()
-  "Calculate the maximum sensible indentation for the current line."
-  (save-excursion
-    (beginning-of-line)
-    (if (looking-at yaml-document-delimiter-re) 0
-      (forward-line -1)
-      (while (and (looking-at yaml-blank-line-re)
-                  (> (point) (point-min)))
-        (forward-line -1))
-      (+ (current-indentation)
-         (if (looking-at yaml-nested-map-re) yaml-indent-offset 0)
-         (if (looking-at yaml-nested-sequence-re) yaml-indent-offset 0)
-         (if (looking-at yaml-block-literal-re) yaml-indent-offset 0)))))
+(defvar yaml-indent-line-state nil
+  "State variable to track consecutive calls to `yaml-indent-line`.")
 
 (defun yaml-indent-line ()
   "Indent the current line.
@@ -367,14 +355,82 @@ maximum sensible indentation.  Each immediately subsequent usage will
 back-dent the line by `yaml-indent-offset' spaces.  On reaching column
 0, it will cycle back to the maximum sensible indentation."
   (interactive "*")
-  (let ((ci (current-indentation))
-        (need (yaml-compute-indentation)))
+  (let ((current-indent (current-indentation))
+        (computed-indent (yaml-compute-indentation)))
     (save-excursion
-      (if (and (equal last-command this-command) (/= ci 0))
-          (indent-line-to (* (/ (- ci 1) yaml-indent-offset) yaml-indent-offset))
-        (indent-line-to need)))
+      (if (and (eq last-command 'yaml-indent-line) (/= current-indent 0))
+          ;; Consecutive calls: back-dent by `yaml-indent-offset'
+          (progn
+            (setq yaml-indent-line-state (if yaml-indent-line-state
+                                            (max 0 (- yaml-indent-line-state yaml-indent-offset))
+                                          (- current-indent yaml-indent-offset)))
+            (indent-line-to yaml-indent-line-state))
+        ;; First call: indent to the maximum sensible indentation
+        (indent-line-to computed-indent)
+        (setq yaml-indent-line-state computed-indent)))
     (if (< (current-column) (current-indentation))
-        (forward-to-indentation 0))))
+        (forward-to-indentation 0))
+    (setq this-command 'yaml-indent-line)))
+
+(defun yaml-compute-indentation ()
+  "Calculate the maximum sensible indentation for the current line."
+  (save-excursion
+    (beginning-of-line)
+    (let ((current-indent (current-indentation))
+          (base-indent 0)
+          (nested-indent 0)
+          (block-literal-indent 0)
+          (block-literal-line nil)
+          (is-nested-sequence nil))
+
+      ;; Move up to the first non-blank, non-comment line
+      (forward-line -1)
+      (while (and (or (looking-at yaml-blank-line-re)
+                      (looking-at-p "^[ \t]*#"))
+                  (> (point) (point-min)))
+        (forward-line -1))
+      (setq base-indent (current-indentation))
+
+      ;; Check if the previous line is a block literal
+      (when (looking-at-p yaml-block-literal-re)
+        (setq block-literal-indent (+ base-indent 2))  ; Indent just one space past the dash and pipe
+        (setq block-literal-line t))
+
+      ;; Check if the previous line is a nested sequence
+      (when (and (not block-literal-line)
+                 (looking-at-p yaml-nested-sequence-re))
+        (setq nested-indent yaml-indent-offset)
+        (setq is-nested-sequence t))
+
+      ;; Check if the previous line is a hash key
+      (when (and (not block-literal-line)
+                 (not is-nested-sequence)
+                 (looking-at-p yaml-hash-key-re))
+        (setq nested-indent yaml-indent-offset))
+
+      ;; Determine the appropriate indentation
+      (cond
+       (block-literal-line
+        block-literal-indent)
+       (is-nested-sequence
+        (if (>= current-indent base-indent)
+            current-indent
+          (+ base-indent nested-indent)))
+       (t
+        (min (+ base-indent nested-indent) current-indent))))))
+
+(defun yaml-indent-region (start end)
+  "Indent each line in the region from START to END."
+  (interactive "r")
+  (save-excursion
+    (goto-char start)
+    (while (< (point) end)
+      (let ((current-indent (current-indentation))
+            (computed-indent (yaml-compute-indentation)))
+        (unless (= current-indent computed-indent)
+          (indent-line-to computed-indent)))
+      (forward-line 1)))
+  (message "Indented region from %d to %d" start end))
 
 (defun yaml-electric-backspace (arg)
   "Delete characters or back-dent the current line.


### PR DESCRIPTION
- add some descriptions of what we expect in form of erts files, i hope these will help describing which expectations we agree on for e.g. https://github.com/yoshiki/yaml-mode/issues/97 (the current code still indents them because that was still what i expected, i am now beginning to consider changing my mind and expecting lists to not be indented which would mean changing one test https://github.com/yoshiki/yaml-mode/blob/1fc200a0b173557605fe925c572cc2c83c13c3c4/test-files/yaml-mode-list-items-with-dash.erts  and the code a bit) https://github.com/yoshiki/yaml-mode/issues/56
- The yaml-compute-indentation function is refined to handle nested maps, sequences, and block literals the way i expect it to and i hope it resolves https://github.com/yoshiki/yaml-mode/issues/49.
- maintain indentation cycling behaviour (i hope i did this correctly)

