### PR TITLE
Fix wrong-type-argument error at beginning of buffer

### DIFF
--- a/yaml-mode.el
+++ b/yaml-mode.el
@@ -272,7 +272,8 @@ that key is pressed to begin a block literal."
              (sps (save-excursion (syntax-ppss (1- pt)))))
         (when (not (nth 8 sps))
           (cond
-           ((and (char-equal ?' (char-before (1- pt)))
+           ((and (char-before (1- pt))
+                 (char-equal ?' (char-before (1- pt)))
                  (char-equal ?' (char-before pt)))
             (put-text-property (- pt 2) pt
                                'syntax-table (string-to-syntax "w"))


### PR DESCRIPTION
yaml-mode-syntax-propertize-function calls (char-equal ?' (char-before (1- pt))) without first checking that char-before returns non-nil. When a quote character is the very first character in the buffer, pt is 2 (point is right after the match), (1- pt) is 1, and (char-before 1) returns nil since there is nothing before the start of the buffer.  That nil is passed to char-equal, which signals (wrong-type-argument characterp nil).

This is triggered by any YAML file that starts with a quoted key, for example:

```
    "key": value
```

Add a nil guard for char-before before passing its result to char-equal, matching the pattern already used a few lines below in the same function for the non-whitespace character check.